### PR TITLE
daemon: make tdp_service optional

### DIFF
--- a/src/daemon/user.rs
+++ b/src/daemon/user.rs
@@ -109,7 +109,12 @@ pub(crate) type Command = DaemonCommand<()>;
 
 async fn create_connections(
     channel: Sender<Command>,
-) -> Result<(Connection, Connection, JobManagerService, TdpManagerService)> {
+) -> Result<(
+    Connection,
+    Connection,
+    JobManagerService,
+    Result<TdpManagerService>,
+)> {
     let system = Connection::system().await?;
     let connection = Builder::session()?
         .name("com.steampowered.SteamOSManager1")?
@@ -121,8 +126,7 @@ async fn create_connections(
     let jm_service = JobManagerService::new(job_manager, rx, system.clone());
 
     let (tdp_tx, rx) = unbounded_channel();
-    let tdp_service = TdpManagerService::new(rx, &system, &connection).await?;
-
+    let tdp_service = TdpManagerService::new(rx, &system, &connection).await;
     create_interfaces(connection.clone(), system.clone(), channel, jm_tx, tdp_tx).await?;
 
     Ok((connection, system, jm_service, tdp_service))
@@ -151,7 +155,9 @@ pub async fn daemon() -> Result<()> {
     let mut daemon = Daemon::new(subscriber, system, rx).await?;
 
     daemon.add_service(mirror_service);
-    daemon.add_service(tdp_service);
+    if let Ok(tdp_service) = tdp_service {
+        daemon.add_service(tdp_service);
+    }
 
     session.object_server().at("/", ObjectManager {}).await?;
 


### PR DESCRIPTION
[Jovian NixOS](https://github.com/Jovian-Experiments/Jovian-NixOS) uses this project for enabling SteamOS-like functionality on the Steam Deck (and other devices).
There seems to have been recent addition of requiring a valid `TDPManagerService` in the user daemon, which in turn breaks the service for people who use the Jovian NixOS project on devices other than the steam deck variants (e.g. HTPCs with AMD hardware).
Fix for this is to make the TDP configuration optional in the user daemon.
